### PR TITLE
Add xenon to monitor code's complexity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,8 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.7'
-    - run: pip install flake8
-    - run: pip install isort
-    - run: flake8 .
-    - run: isort .
+    - run: pip install flake8 isort xenon
+    - run: make lint
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,9 @@ help: ## show this message
 
 
 lint: ## lint code
-	python3 -m flake8 .
-	python3 -m isort .
+	flake8 .
+	isort .
+	xenon --max-absolute C --max-modules B --max-average A *.py --exclude addon_updater.py,addon_updater_ops.py,ui.py,search.py
 
 
 test: ## test code


### PR DESCRIPTION
[Essa ferramenta](https://github.com/hana3d/hana3d/pull/new/add-xenon) é mto legal para identificar os problemas no código. Acho que pode ajudar inclusive na priorização de refactors.

O problema é que ela acusa vários problemas então tive que dar vários excludes e abaixar o requisito de `A` para `C` pra fazer passar 😅 😅 😅 

se eu rodo com `B`, ele retorna o seguinte:

```
$ xenon --max-absolute B --max-modules B --max-average A *.py
ERROR:xenon:block "addon_updater.py:986 deepMergeDirectory" has a rank of E
ERROR:xenon:block "addon_updater.py:863 unpack_staged_zip" has a rank of D
ERROR:xenon:block "addon_updater.py:1349 run_update" has a rank of D
ERROR:xenon:block "addon_updater.py:582 get_tags" has a rank of D
ERROR:xenon:block "addon_updater.py:1218 check_for_update" has a rank of C
ERROR:xenon:block "addon_updater.py:732 stage_repository" has a rank of C
ERROR:xenon:block "addon_updater.py:656 get_raw" has a rank of C
ERROR:xenon:block "addon_updater_ops.py:889 update_settings_ui" has a rank of D
ERROR:xenon:block "addon_updater_ops.py:1058 update_settings_ui_condensed" has a rank of D
ERROR:xenon:block "addon_updater_ops.py:1179 skip_tag_function" has a rank of C
ERROR:xenon:block "append_link.py:137 append_scene" has a rank of C
ERROR:xenon:block "append_link.py:237 append_objects" has a rank of C
ERROR:xenon:block "autothumb.py:33 generate_model_thumbnail" has a rank of C
ERROR:xenon:block "bg_blender.py:183 KillBgProcess" has a rank of C
ERROR:xenon:block "bg_blender.py:205 execute" has a rank of C
ERROR:xenon:block "download.py:167 check_unused" has a rank of C
ERROR:xenon:block "download.py:393 import_model" has a rank of C
ERROR:xenon:block "download.py:489 set_asset_props" has a rank of C
ERROR:xenon:block "paths.py:117 get_download_dirs" has a rank of C
ERROR:xenon:block "render.py:451 execute" has a rank of C
ERROR:xenon:block "search.py:102 timer_update" has a rank of E
ERROR:xenon:block "search.py:331 run" has a rank of E
ERROR:xenon:block "search.py:567 search" has a rank of C
ERROR:xenon:block "search.py:316 Searcher" has a rank of C
ERROR:xenon:block "types.py:457 get_active_image" has a rank of C
ERROR:xenon:block "ui.py:1087 modal" has a rank of F
ERROR:xenon:block "ui.py:610 draw_callback_2d_search" has a rank of E
ERROR:xenon:block "ui.py:1043 AssetBarOperator" has a rank of D
ERROR:xenon:block "ui.py:1672 modal" has a rank of D
ERROR:xenon:block "ui.py:224 draw_tooltip" has a rank of C
ERROR:xenon:block "ui.py:521 draw_callback_2d_progress" has a rank of C
ERROR:xenon:block "ui.py:1665 DefaultNamesOperator" has a rank of C
ERROR:xenon:block "ui_panels.py:523 draw_generate_panel" has a rank of C
ERROR:xenon:block "ui_panels.py:300 draw" has a rank of C
ERROR:xenon:block "ui_panels.py:115 draw_panel_common_upload" has a rank of C
ERROR:xenon:block "ui_panels.py:289 VIEW3D_PT_hana3d_unified" has a rank of C
ERROR:xenon:block "upload.py:54 get_export_data" has a rank of C
ERROR:xenon:block "upload.py:257 start_upload" has a rank of C
ERROR:xenon:block "utils.py:675 check_meshprops" has a rank of C
ERROR:xenon:block "utils.py:96 get_selected_models" has a rank of C
```

@papukweh 
@impadalko 
@naiane-yanachi-r2u 
@fabio-nukui 