### PR TITLE
Move most operators to a new folder

### DIFF
--- a/src/ui/operators/__init__.py
+++ b/src/ui/operators/__init__.py
@@ -1,0 +1,7 @@
+# flake8: noqa
+"""Blender UI Operators."""
+
+from .default_names import DefaultNamesOperator
+from .run_asset_bar import RunAssetBarWithContext
+from .transfer_data import TransferHana3DData
+from .undo import UndoWithContext

--- a/src/ui/operators/default_names.py
+++ b/src/ui/operators/default_names.py
@@ -1,5 +1,5 @@
 """Assign default object name as props name and object render job name."""
-from typing import List, Set
+from typing import Set
 
 import bpy
 
@@ -47,17 +47,14 @@ class DefaultNamesOperator(bpy.types.Operator):
             else:
                 previous_names = [job['job_name'] for job in props.render_data['jobs']]
             base_name = props.name or asset.name or 'Render'
-            props.render_job_name = self._new_render_job_name(base_name, previous_names)
+            for n in range(1000):  # noqa: WPS111
+                new_name = f'{base_name}_{n:03d}'
+                if new_name not in previous_names:
+                    break
+            props.render_job_name = new_name
 
         return {'PASS_THROUGH'}
 
     def invoke(self, context: bpy.types.Context, event: bpy.types.Event) -> Set[str]:  # noqa: D102
         context.window_manager.modal_handler_add(self)
         return {'RUNNING_MODAL'}
-
-    def _new_render_job_name(self, base_name: str, previous_names: List[str]) -> str:
-        for n in range(1000):  # noqa: WPS111
-            new_name = f'{base_name}_{n:03d}'
-            if new_name not in previous_names:
-                break
-        return new_name

--- a/src/ui/operators/default_names.py
+++ b/src/ui/operators/default_names.py
@@ -1,0 +1,63 @@
+"""Assign default object name as props name and object render job name."""
+from typing import List, Set
+
+import bpy
+
+from .... import utils
+from ....config import HANA3D_DESCRIPTION, HANA3D_NAME, HANA3D_UI
+
+
+class DefaultNamesOperator(bpy.types.Operator):
+    """Assign default object name as props name and object render job name."""
+
+    bl_idname = f'view3d.{HANA3D_NAME}_default_name'
+    bl_label = f'{HANA3D_DESCRIPTION} Default Name'
+    bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
+
+    def modal(self, context: bpy.types.Context, event: bpy.types.Event) -> Set[str]:  # noqa: D102, WPS210, E501
+        # This is for case of closing the area or changing type:
+        ui_props = getattr(context.window_manager, HANA3D_UI)
+
+        if ui_props.turn_off:
+            return {'CANCELLED'}
+
+        if event.type not in {'LEFTMOUSE', 'RIGHTMOUSE', 'ENTER'}:
+            return {'PASS_THROUGH'}
+
+        if ui_props.down_up == 'SEARCH':
+            search_props = utils.get_search_props()
+            if search_props.workspace != '' and search_props.tags_list:
+                search_props.workspace = search_props.workspace
+
+        asset = utils.get_active_asset()
+        if asset is None:
+            return {'PASS_THROUGH'}
+
+        props = getattr(asset, HANA3D_NAME)
+
+        if ui_props.down_up == 'UPLOAD':
+            if props.workspace != '' and props.tags_list:
+                props.workspace = props.workspace
+            if props.name == '' and props.name != asset.name:
+                props.name = asset.name
+
+        if props.render_job_name == '':
+            if 'jobs' not in props.render_data:
+                previous_names = []
+            else:
+                previous_names = [job['job_name'] for job in props.render_data['jobs']]
+            base_name = props.name or asset.name or 'Render'
+            props.render_job_name = self._new_render_job_name(base_name, previous_names)
+
+        return {'PASS_THROUGH'}
+
+    def invoke(self, context: bpy.types.Context, event: bpy.types.Event) -> Set[str]:  # noqa: D102
+        context.window_manager.modal_handler_add(self)
+        return {'RUNNING_MODAL'}
+
+    def _new_render_job_name(self, base_name: str, previous_names: List[str]) -> str:
+        for n in range(1000):  # noqa: WPS111
+            new_name = f'{base_name}_{n:03d}'
+            if new_name not in previous_names:
+                break
+        return new_name

--- a/src/ui/operators/default_names.py
+++ b/src/ui/operators/default_names.py
@@ -27,6 +27,8 @@ class DefaultNamesOperator(bpy.types.Operator):
         if ui_props.down_up == 'SEARCH':
             search_props = utils.get_search_props()
             if search_props.workspace != '' and search_props.tags_list:
+                # This is done to force the UI to update
+                # TODO: refactor this so this happens more explicitly?
                 search_props.workspace = search_props.workspace
 
         asset = utils.get_active_asset()
@@ -37,6 +39,8 @@ class DefaultNamesOperator(bpy.types.Operator):
 
         if ui_props.down_up == 'UPLOAD':
             if props.workspace != '' and props.tags_list:
+                # This is done to force the UI to update
+                # TODO: refactor this so this happens more explicitly?
                 props.workspace = props.workspace
             if props.name == '' and props.name != asset.name:
                 props.name = asset.name

--- a/src/ui/operators/run_asset_bar.py
+++ b/src/ui/operators/run_asset_bar.py
@@ -1,0 +1,34 @@
+"""Run Asset Bar With Context Operator."""
+from typing import Set
+
+import bpy
+
+from ....config import HANA3D_DESCRIPTION, HANA3D_NAME
+from ....report_tools import execute_wrapper
+from ..main import UI
+
+
+class RunAssetBarWithContext(bpy.types.Operator):
+    """Regenerate cobweb."""
+
+    bl_idname = f'object.{HANA3D_NAME}_run_assetbar_fix_context'
+    bl_label = f'{HANA3D_DESCRIPTION} assetbar with fixed context'
+    bl_description = 'Run assetbar with fixed context'
+    bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
+
+    @execute_wrapper
+    def execute(self, context: bpy.types.Context) -> Set[str]:  # noqa: D102,WPS210
+        c_dict = bpy.context.copy()
+        c_dict.update(region='WINDOW')
+        if context.area is None or context.area.type != 'VIEW_3D':
+            window, area, region = UI().get_largest_view3d()
+            override = {'window': window, 'screen': window.screen, 'area': area, 'region': region}
+            c_dict.update(override)
+        asset_bar_op = getattr(bpy.ops.view3d, f'{HANA3D_NAME}_asset_bar')
+        asset_bar_op(
+            c_dict,
+            'INVOKE_REGION_WIN',
+            keep_running=True,
+            do_search=False,
+        )
+        return {'FINISHED'}

--- a/src/ui/operators/run_asset_bar.py
+++ b/src/ui/operators/run_asset_bar.py
@@ -16,7 +16,7 @@ class RunAssetBarWithContext(bpy.types.Operator):
     bl_description = 'Run assetbar with fixed context'
     bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
 
-    @execute_wrapper
+    @execute_wrapper  # noqa: WPS210
     def execute(self, context: bpy.types.Context) -> Set[str]:  # noqa: WPS210,D102
         c_dict = bpy.context.copy()
         c_dict.update(region='WINDOW')

--- a/src/ui/operators/run_asset_bar.py
+++ b/src/ui/operators/run_asset_bar.py
@@ -17,7 +17,7 @@ class RunAssetBarWithContext(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
 
     @execute_wrapper
-    def execute(self, context: bpy.types.Context) -> Set[str]:  # noqa: D102,WPS210
+    def execute(self, context: bpy.types.Context) -> Set[str]:  # noqa: WPS210,D102
         c_dict = bpy.context.copy()
         c_dict.update(region='WINDOW')
         if context.area is None or context.area.type != 'VIEW_3D':

--- a/src/ui/operators/transfer_data.py
+++ b/src/ui/operators/transfer_data.py
@@ -1,0 +1,30 @@
+"""Transfer Hana3D Data Operator."""
+from typing import Set
+
+import bpy
+
+from ....config import HANA3D_DESCRIPTION, HANA3D_NAME
+from ....report_tools import execute_wrapper
+
+
+class TransferHana3DData(bpy.types.Operator):
+    """Regenerate cobweb."""
+
+    bl_idname = f'object.{HANA3D_NAME}_data_transfer'
+    bl_label = f'Transfer {HANA3D_DESCRIPTION} data'
+    bl_description = (
+        'Transfer hana3d metadata from one object to another when fixing uploads'
+        + ' with wrong parenting.'
+    )
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @execute_wrapper
+    def execute(self, context: bpy.types.Context) -> Set[str]:  # noqa: D102
+        source_ob = bpy.context.active_object
+        for target_ob in bpy.context.selected_objects:
+            if target_ob != source_ob:
+                target_ob.property_unset(HANA3D_NAME)
+                for key in source_ob.keys():
+                    target_ob[key] = source_ob[key]
+        source_ob.property_unset(HANA3D_NAME)
+        return {'FINISHED'}

--- a/src/ui/operators/transfer_data.py
+++ b/src/ui/operators/transfer_data.py
@@ -13,7 +13,7 @@ class TransferHana3DData(bpy.types.Operator):
     bl_idname = f'object.{HANA3D_NAME}_data_transfer'
     bl_label = f'Transfer {HANA3D_DESCRIPTION} data'
     bl_description = (
-        'Transfer hana3d metadata from one object to another when fixing uploads'
+        f'Transfer {HANA3D_DESCRIPTION} metadata from one object to another when fixing uploads'
         + ' with wrong parenting.'
     )
     bl_options = {'REGISTER', 'UNDO'}

--- a/src/ui/operators/undo.py
+++ b/src/ui/operators/undo.py
@@ -1,0 +1,33 @@
+"""Undo With Context Operator."""
+from typing import Set
+
+import bpy
+
+from ....config import HANA3D_DESCRIPTION, HANA3D_NAME
+from ....report_tools import execute_wrapper
+from ..main import UI
+
+
+class UndoWithContext(bpy.types.Operator):
+    """Regenerate cobweb."""
+
+    bl_idname = f'wm.{HANA3D_NAME}_undo_push_context'
+    bl_label = f'{HANA3D_DESCRIPTION} undo push'
+    bl_description = f'{HANA3D_DESCRIPTION} undo push with fixed context'
+    bl_options = {'REGISTER', 'UNDO', 'INTERNAL'}
+
+    message: bpy.props.StringProperty(   # type: ignore
+        'Undo Message',
+        default=f'{HANA3D_DESCRIPTION} operation',
+    )
+
+    @execute_wrapper
+    def execute(self, context: bpy.types.Context) -> Set[str]:  # noqa: D102
+        c_dict = bpy.context.copy()
+        c_dict.update(region='WINDOW')
+        if context.area is None or context.area.type != 'VIEW_3D':
+            window, area, region = UI().get_largest_view3d()
+            override = {'window': window, 'screen': window.screen, 'area': area, 'region': region}
+            c_dict.update(override)
+        bpy.ops.ed.undo_push(c_dict, 'INVOKE_REGION_WIN', message=self.message)
+        return {'FINISHED'}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 100
-ignore = F821,F722,W503,WPS300,WPS305,WPS226,WPS441,I001
+ignore = F821,F722,W503,WPS300,WPS305,WPS226,WPS441,I001,WPS231,WPS232
 exclude = .git,env
 
 [isort]


### PR DESCRIPTION
Desabilitei as regras de complexidade porque elas eram meio arbitrárias: a complexidade calculada era impossível de debugar e alguns métodos como o `get_largest_view3d` não passavam mesmo não sendo muito complexos (e aumentavam a complexidade do módulo). Prefiro que a validação de complexidade seja feita manualmente nos PRs.

Ainda não migrei o operador da `AssetBar` por esse ser o mais complicado