### PR TITLE
Fix batch download working only after another async task

### DIFF
--- a/src/download/__init__.py
+++ b/src/download/__init__.py
@@ -38,6 +38,7 @@ from bpy.props import (
 
 from .downloader import Downloader
 from .lib import check_existing
+from ..async_loop import ensure_async_loop
 from ..preferences.profile import update_libraries_list, update_tags_list
 from ..search.query import Query
 from ..search.search import Search
@@ -732,6 +733,7 @@ class Hana3DBatchDownloadOperator(bpy.types.Operator):  # noqa : WPS338
         else:
             ui.add_report(f'Downloading {n_assets_to_download} assets')
 
+        ensure_async_loop()
         for _, search_result in zip(  # noqa : WPS352
             range(self.batch_size),
             search.results[self.object_count:],


### PR DESCRIPTION
Por algum motivo, o batch download só funcionava quando outra task async tinha sido executada antes. Aparentemente, o problema é relacionado com a inicialização do async loop, mas não tenho certeza se essa é a melhor solução.

Por outro lado, não tive mais problemas com o batch download, então acredito que mudar para async tenha resolvido (embora não dê para ter certeza)