### PR TITLE
Fix batch download not placing objects properly

### DIFF
--- a/src/download/__init__.py
+++ b/src/download/__init__.py
@@ -731,8 +731,7 @@ class Hana3DBatchDownloadOperator(bpy.types.Operator):  # noqa : WPS338
         dy = -1
         for _ in range(self.object_count):  # noqa : WPS122
             if pos_x == pos_y or (pos_x < 0 and pos_x == -pos_y) or (pos_x > 0 and pos_x == 1 - pos_y):  # noqa : WPS220,WPS221
-                dx = -dy
-                dy = dx
+                dx, dy = -dy, dx  # noqa: WPS434
             pos_x, pos_y = pos_x + dx, pos_y + dy
         self.object_count += 1
         return (self.grid_distance * pos_x, self.grid_distance * pos_y, 0)
@@ -781,7 +780,7 @@ class Hana3DBatchDownloadOperator(bpy.types.Operator):  # noqa : WPS338
         ensure_async_loop()
         for _, asset_data in zip(  # noqa : WPS352
             range(self.batch_size),
-            get_search_results()[self.object_count:],
+            search_results[self.object_count:],
         ):
             location = self._get_location()
             kwargs = {

--- a/src/panels/download.py
+++ b/src/panels/download.py
@@ -13,7 +13,6 @@ class Hana3DDownloadPanel(Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
     bl_label = f'Downloads {HANA3D_DESCRIPTION}'
-    bl_options = {'DEFAULT_CLOSED'}
 
     @classmethod
     def poll(cls, context):  # noqa: D102


### PR DESCRIPTION
Faz o painel de downloads começar aberto (o que faz sentido dado que ele só existe quando tem downloads acontecendo)

A regra WPS434 (ReassigningVariableToItselfViolation) foi desabilitada porque ela dá um falso positivo, acredito inclusive que esse erro tenha surgido justamente por causa desse falso positivo (o código estava com a troca de variáveis feita via tuple antes)