### PR TITLE
Allow to download asset from edit panel

### DIFF
--- a/hana3d_types.py
+++ b/hana3d_types.py
@@ -990,7 +990,18 @@ class Hana3DUnifiedProps(PropertyGroup):
 class Hana3DEditAsset(PropertyGroup, Hana3DCommonUploadProps):
     """Hana3D Edit Asset Info."""
 
-    pass    # noqa: WPS420, WPS604
+    asset_type: EnumProperty(  # type: ignore
+        name='Type',
+        items=search_asset_type_items,
+        description='Asset type',
+        default='MODEL',
+    )
+
+    asset_index: IntProperty(  # type: ignore
+        name='Asset Index',
+        description='asset index in search results',
+        default=-1,
+    )
 
 
 UploadProps = Union[

--- a/src/edit_asset/edit.py
+++ b/src/edit_asset/edit.py
@@ -37,7 +37,8 @@ def set_edit_props(asset_index: int):
     asset_props.name = asset_data.name
     asset_props.tags = ','.join(asset_data.tags)
     asset_props.description = asset_data.description
-    asset_props.asset_type = asset_data.asset_type
+    asset_props.asset_type = asset_data.asset_type.upper()
+    asset_props.asset_index = asset_index
 
     update_tags_list(asset_props, bpy.context)
     for tag in asset_data.tags:

--- a/src/panels/upload.py
+++ b/src/panels/upload.py
@@ -16,8 +16,7 @@ class Hana3DUploadPanel(Panel):  # noqa: WPS214
     bl_idname = f'VIEW3D_PT_{HANA3D_NAME}_upload'
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
-    bl_label = f'Upload Assets to {HANA3D_DESCRIPTION}'
-    bl_options = {'DEFAULT_CLOSED'}
+    bl_label = f'Manage Assets in {HANA3D_DESCRIPTION}'
 
     @classmethod
     def poll(cls, context):  # noqa: D102
@@ -114,6 +113,8 @@ class Hana3DUploadPanel(Panel):  # noqa: WPS214
         row.operator(f'object.{HANA3D_NAME}_delete', text=optext, icon='CANCEL')
 
         row = layout.row()
+        row.scale_y = 2.0
+        row.enabled = props.asset_index >= 0
         optext = 'Download to Scene'
         op = row.operator(f'scene.{HANA3D_NAME}_download', text=optext, icon='IMPORT')
         op.asset_index = props.asset_index

--- a/src/panels/upload.py
+++ b/src/panels/upload.py
@@ -106,12 +106,18 @@ class Hana3DUploadPanel(Panel):  # noqa: WPS214
 
         row = layout.row()
         row.scale_y = 2.0
-        optext = 'Edit Asset Info'
+        optext = 'Update Asset Info'
         row.operator(f'object.{HANA3D_NAME}_edit', text=optext, icon='INFO')
 
         row = layout.row()
         optext = 'Delete Asset'
         row.operator(f'object.{HANA3D_NAME}_delete', text=optext, icon='CANCEL')
+
+        row = layout.row()
+        optext = 'Download to Scene'
+        op = row.operator(f'scene.{HANA3D_NAME}_download', text=optext, icon='IMPORT')
+        op.asset_index = props.asset_index
+        op.asset_type = props.asset_type
 
     def _draw_workspace(
         self,


### PR DESCRIPTION
Atualiza texto do botão de atualizar informações e adiciona botão de download do asset nesse painel.

Como fica o painel com essa mudança:
![image](https://user-images.githubusercontent.com/16337001/107571399-9e197880-6bc9-11eb-99f2-e25da5aa2be8.png)

Dos pedidos de UX do Giovanni, ainda não fiz o botão de update ficar disabled quando não há mudanças (não tenho certeza de como fazer isso)