### PR TITLE
Fix get next thumbnails

### DIFF
--- a/src/search/operator.py
+++ b/src/search/operator.py
@@ -1,6 +1,5 @@
 """Search operator."""
 
-import json
 import logging
 import os
 from typing import Dict, List, Tuple
@@ -321,8 +320,6 @@ class SearchOperator(AsyncModalOperatorMixin, bpy.types.Operator):  # noqa: WPS2
         result_field: List[AssetData],
     ):
         index = self.next_index
-        logging.debug(f'Loading thumbnails: {len(small_thumbnails)} small and {len(large_thumbnails)} large')
-        logging.debug(f'Number of assets: {len(result_field)}')
         for small, large in zip(small_thumbnails, large_thumbnails):
             imgpath, url = small
             imgpath_large, url_large = large

--- a/src/search/operator.py
+++ b/src/search/operator.py
@@ -78,9 +78,11 @@ class SearchOperator(AsyncModalOperatorMixin, bpy.types.Operator):  # noqa: WPS2
             context: Blender context
 
         Returns:
-            bool: can always search
+            bool: only search if no search operation is running
         """
-        return True
+        asset_type = self._get_asset_type_from_ui()
+        search_props = get_search_props(asset_type)
+        return not search_props.is_searching
 
     async def async_execute(self, context):
         """Search async execute.
@@ -111,6 +113,10 @@ class SearchOperator(AsyncModalOperatorMixin, bpy.types.Operator):  # noqa: WPS2
         logging.debug(f'Search options: {str(options)}')
         ui.add_report(text=f'{HANA3D_DESCRIPTION} searching...', timeout=2)
 
+        if search_props.is_searching:
+            return {'FINISHED'}
+        search_props.is_searching = True
+
         try:
             request_data = await search_assets(query, options, ui)
         except Exception:
@@ -130,7 +136,7 @@ class SearchOperator(AsyncModalOperatorMixin, bpy.types.Operator):  # noqa: WPS2
 
             if options['get_next']:
                 previous_results = get_search_results(asset_type)
-                self.next_index += len(previous_results)
+                self.next_index = len(previous_results)
                 result_field = previous_results + result_field
                 set_search_results(asset_type, result_field)
             else:
@@ -141,7 +147,6 @@ class SearchOperator(AsyncModalOperatorMixin, bpy.types.Operator):  # noqa: WPS2
 
             if len(result_field) < ui_props.scrolloffset:
                 ui_props.scrolloffset = 0
-
             text = f'Found {request_data["count"]} results. '  # noqa #501
             ui.add_report(text=text)
         else:
@@ -319,7 +324,6 @@ class SearchOperator(AsyncModalOperatorMixin, bpy.types.Operator):  # noqa: WPS2
         asset_type: AssetType,
         result_field: List[AssetData],
     ):
-        index = self.next_index
         for small, large in zip(small_thumbnails, large_thumbnails):
             imgpath, url = small
             imgpath_large, url_large = large
@@ -329,8 +333,9 @@ class SearchOperator(AsyncModalOperatorMixin, bpy.types.Operator):  # noqa: WPS2
                 await download_thumbnail(imgpath_large, url_large)
             current_asset_type = self._get_asset_type_from_ui()
             if current_asset_type == asset_type:
-                load_preview(asset_type, result_field[index], index)
-            index += 1
+                load_preview(asset_type, result_field[self.next_index], self.next_index)
+            self.next_index += 1
+
 
 
 classes = (

--- a/src/search/search.py
+++ b/src/search/search.py
@@ -86,7 +86,6 @@ def load_preview(asset_type: AssetType, search_result: AssetData, index: int):
     if search_result is None:
         return
 
-    logging.debug('Loading preview')
     if search_result.thumbnail_small == '':
         logging.debug('No small thumbnail, will load placeholder')
         load_placeholder_thumbnail(index, search_result.id)
@@ -206,7 +205,6 @@ def run_operator(get_next=False):
     """
     search_props = get_search_props()
     if not search_props.is_searching:
-        search_props.is_searching = True
         logging.debug(f'Running search operator with get_next = {get_next}')
         search_op = getattr(bpy.ops.view3d, f'{HANA3D_NAME}_search')
         search_op(get_next=get_next)

--- a/src/ui/operators/asset_bar.py
+++ b/src/ui/operators/asset_bar.py
@@ -281,7 +281,7 @@ class AssetBarOperator(bpy.types.Operator):  # noqa: WPS338, WPS214
         original_search_results = search.get_original_search_results()
         if original_search_results is not None and original_search_results.get('next') is not None:
             len_search = len(search.get_search_results())
-            image_name = utils.previmg_name(len_search-1)
+            image_name = utils.previmg_name(len_search - 1)
             img = bpy.data.images.get(image_name)
             if img:
                 logging.debug(f'{image_name} has already loaded, will continue search')
@@ -398,7 +398,7 @@ class AssetBarOperator(bpy.types.Operator):  # noqa: WPS338, WPS214
             return {'PASS_THROUGH'}
         len_search = len(search_results)
         if ui_props.scrolloffset > len_search:
-            ui_props.scrolloffset = 0 
+            ui_props.scrolloffset = 0
         elif len_search - ui_props.scrolloffset < ui_props.total_count + 10:  # noqa: WPS221,WPS204
             self.search_more()
         if event.type in {'WHEELUPMOUSE', 'WHEELDOWNMOUSE', 'TRACKPADPAN'}:


### PR DESCRIPTION
- Cria um índice pro operador de search saber a partir de qual thumbnail preencher no caso de `get_next = True`
- Modifica condições pro `search` rodar: como o `get_next` é acionado dentro da `asset_bar` se o usuário estiver em certa região dela, isso faz com que o operador seja chamado múltiplas vezes, cada chamada interrompendo a anterior, fazendo com que thumbnails de id 1000+ estivessem sido carregadas enquanto o usuário ainda está no id 100-200 na asset_bar

Videozinho:

https://user-images.githubusercontent.com/28656428/109158591-56aaf480-7752-11eb-947d-e7ac9fde33b1.mp4



Resolve [essa issue](https://real2u.atlassian.net/browse/HANA3DESK-39)
