### PR TITLE
Force thumbnails to load when opening a scene

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -81,6 +81,19 @@ def scene_load(context):
             bpy.app.timers.register(authentication.refresh_token_timer)
 
 
+@ persistent
+def thumbnail_load(context):
+    """Force thumbnails to load when opening a scene.
+
+    Parameters:
+        context: Blender context
+    """
+    for scene_obj in bpy.data.objects:
+        props = getattr(scene_obj, HANA3D_NAME)
+        if props.thumbnail != '':
+            props.force_preview_reload = True
+
+
 @ bpy.app.handlers.persistent
 def check_timers_timer():
     """Check if all timers are registered regularly.
@@ -339,6 +352,7 @@ def register():
 
     bpy.app.timers.register(check_timers_timer, persistent=True)
     bpy.app.handlers.load_post.append(scene_load)
+    bpy.app.handlers.load_post.append(thumbnail_load)
 
 
 def unregister():
@@ -346,6 +360,7 @@ def unregister():
         module.unregister()
 
     bpy.app.timers.unregister(check_timers_timer)
+    bpy.app.handlers.load_post.remove(thumbnail_load)
     bpy.app.handlers.load_post.remove(scene_load)
     bpy.utils.unregister_class(Hana3DAddonPreferences)
     addon_updater_ops.unregister()

--- a/hana3d_types.py
+++ b/hana3d_types.py
@@ -470,9 +470,13 @@ class Hana3DCommonUploadProps:
                 self.custom_props[name] = ''
 
     def update_preview(self, context=None):
-        """Mark upload preview to be updated by draw calllback"""
-        if self.remote_thumbnail:
-            self.force_preview_reload = True
+        """Mark upload preview to be updated by draw callback.
+
+        Parameters:
+            context: Blender context
+        """
+        if self.force_preview_reload:
+            self.force_preview_reload = False
         if self.thumbnail != '':
             self.has_thumbnail = True
             name = str(uuid.uuid4())
@@ -564,7 +568,8 @@ class Hana3DCommonUploadProps:
 
     force_preview_reload: BoolProperty(
         description="True if upload preview image should be updated",
-        default=True,
+        default=False,
+        update=update_preview,
     )
 
     is_generating_thumbnail: BoolProperty(


### PR DESCRIPTION
O `force_preview_reload` não estava sendo usado para nada então acabei reaproveitando ele para esse caso. Não sei se é a melhor abordagem essa sendo sincero dado que a função é executada duas vezes quando o `force_preview_reload` é setado para `True` (a primeira quando vira `True` e a segunda quando a função seta ele para `False`). Alguma sugestão?