### PR TITLE
Previews by asset type

### DIFF
--- a/src/search/search.py
+++ b/src/search/search.py
@@ -88,11 +88,11 @@ def load_preview(asset_type: AssetType, search_result: AssetData, index: int):
 
     if search_result.thumbnail_small == '':
         logging.debug('No small thumbnail, will load placeholder')
-        load_placeholder_thumbnail(index, search_result.id)
+        load_placeholder_thumbnail(asset_type, index, search_result.id)
         return
 
     thumbnail_path = os.path.join(directory, search_result.thumbnail_small)
-    image_name = utils.previmg_name(index)
+    image_name = utils.previmg_name(asset_type, index)
     logging.debug(f'Loading {image_name} in {thumbnail_path}')
 
     if os.path.exists(thumbnail_path):  # sometimes we are unlucky...
@@ -111,23 +111,24 @@ def load_preview(asset_type: AssetType, search_result: AssetData, index: int):
         logging.error('No thumbnail')
 
 
-def load_placeholder_thumbnail(index: int, asset_id: str):
+def load_placeholder_thumbnail(asset_type: AssetType, index: int, asset_id: str):
     """Load placeholder thumbnail for assets without one.
 
     Parameters:
+        asset_type: asset type
         index: index number of the asset in search results
         asset_id: asset id
     """
     placeholder_path = paths.get_addon_thumbnail_path('thumbnail_notready.png')
 
     img = bpy.data.images.load(placeholder_path)
-    img.name = utils.previmg_name(index)
+    img.name = utils.previmg_name(asset_type, index)
 
     hidden_img = bpy.data.images.load(placeholder_path)
     hidden_img.name = f'.{asset_id}'
 
     fullsize_img = bpy.data.images.load(placeholder_path)
-    fullsize_img.name = utils.previmg_name(index, fullsize=True)
+    fullsize_img.name = utils.previmg_name(asset_type, index, fullsize=True)
 
 
 def get_search_results(asset_type: AssetType = None) -> List[AssetData]:

--- a/src/ui/callbacks/asset_bar.py
+++ b/src/ui/callbacks/asset_bar.py
@@ -228,8 +228,9 @@ def draw_tooltip(   # noqa: WPS211
         bgl_helper.draw_text(author_line, xtext, ytext, fsize, tcol)
 
 
-def _load_tooltip_thumbnail(search_result, active_index):
-    image_name = utils.previmg_name(active_index, fullsize=True)
+def _load_tooltip_thumbnail(search_result: search.AssetData, active_index: int):
+    asset_type = search_result.asset_type
+    image_name = utils.previmg_name(asset_type, active_index, fullsize=True)
     directory = paths.get_temp_dir(f'{search_result.asset_type}_search')
     thumbnail_path = os.path.join(directory, search_result.thumbnail)
 
@@ -247,7 +248,7 @@ def _load_tooltip_thumbnail(search_result, active_index):
                 img.reload()
                 img.name = image_name
         else:
-            image_name = utils.previmg_name(active_index)
+            image_name = utils.previmg_name(asset_type, active_index)
             img = bpy.data.images.get(image_name)
         img.colorspace_settings.name = 'Linear'
 
@@ -392,7 +393,7 @@ def draw_callback2d_search(self, context):
                 )
 
                 index = column + ui_props.scrolloffset + row * ui_props.wcount
-                iname = utils.previmg_name(index)
+                iname = utils.previmg_name(asset_type, index)
                 img = bpy.data.images.get(iname)
 
                 max_size = max(img.size[0], img.size[1])
@@ -453,7 +454,7 @@ def draw_callback2d_search(self, context):
 
     elif ui_props.dragging and (ui_props.draw_drag_image or ui_props.draw_snapped_bounds):
         if ui_props.active_index > -1:
-            iname = utils.previmg_name(ui_props.active_index)
+            iname = utils.previmg_name(asset_type, ui_props.active_index)
             img = bpy.data.images.get(iname)
             linelength = 35
             bgl_helper.draw_image(

--- a/src/ui/operators/asset_bar.py
+++ b/src/ui/operators/asset_bar.py
@@ -10,6 +10,7 @@ from mathutils import Vector
 
 from ..callbacks.asset_bar import draw_callback2d, draw_callback3d
 from ..main import UI
+from ...asset.asset_type import AssetType
 from ...edit_asset.edit import set_edit_props
 from ...preferences.preferences import Preferences
 from ...search import search
@@ -276,12 +277,12 @@ class AssetBarOperator(bpy.types.Operator):  # noqa: WPS338, WPS214
     def description(cls, context, properties):  # noqa: D102
         return properties.tooltip
 
-    def search_more(self):
+    def search_more(self, asset_type: AssetType):
         """Search more results."""
         original_search_results = search.get_original_search_results()
         if original_search_results is not None and original_search_results.get('next') is not None:
             len_search = len(search.get_search_results())
-            image_name = utils.previmg_name(len_search - 1)
+            image_name = utils.previmg_name(asset_type, len_search - 1)
             img = bpy.data.images.get(image_name)
             if img:
                 logging.debug(f'{image_name} has already loaded, will continue search')
@@ -400,7 +401,8 @@ class AssetBarOperator(bpy.types.Operator):  # noqa: WPS338, WPS214
         if ui_props.scrolloffset > len_search:
             ui_props.scrolloffset = 0
         elif len_search - ui_props.scrolloffset < ui_props.total_count + 10:  # noqa: WPS221,WPS204
-            self.search_more()
+            asset_type = ui_props.asset_type_search
+            self.search_more(asset_type)
         if event.type in {'WHEELUPMOUSE', 'WHEELDOWNMOUSE', 'TRACKPADPAN'}:
             # scrolling
             mx = event.mouse_region_x

--- a/utils.py
+++ b/utils.py
@@ -134,17 +134,20 @@ def get_active_asset():
     return None
 
 
-def previmg_name(asset_type: AssetType, index: int, fullsize: bool = False):
+def previmg_name(asset_type: AssetType, index: int, fullsize: bool = False) -> str:
     """Get preview image name for asset_type and index.
 
     Parameters:
         asset_type: type of the asset
         index: index of the asset on the asset bar
         fullsize: whether it's a big thumbnail
+
+    Returns:
+        str: image name
     """
     if not fullsize:
         return f'.{HANA3D_NAME}_{asset_type}_preview_{str(index).zfill(2)}'
-    return f'.{HANA3D_NAME}_{asset_type}_preview_full_{str(index).zfill(2)}' 
+    return f'.{HANA3D_NAME}_{asset_type}_preview_full_{str(index).zfill(2)}'
 
 
 def load_prefs():

--- a/utils.py
+++ b/utils.py
@@ -29,6 +29,7 @@ from idprop.types import IDPropertyGroup
 
 from . import paths
 from .config import HANA3D_MATERIALS, HANA3D_NAME, HANA3D_PROFILE, HANA3D_UI
+from .src.asset.asset_type import AssetType
 from .src.ui import colors
 from .src.ui.main import UI
 
@@ -133,11 +134,11 @@ def get_active_asset():
     return None
 
 
-def previmg_name(index, fullsize=False):
+def previmg_name(asset_type: AssetType, index: int, fullsize: bool = False):
     if not fullsize:
-        return f'.{HANA3D_NAME}_preview_' + str(index).zfill(2)
+        return f'.{HANA3D_NAME}_{asset_type}_preview_' + str(index).zfill(2)
     else:
-        return f'.{HANA3D_NAME}_preview_full_' + str(index).zfill(2)
+        return f'.{HANA3D_NAME}_{asset_type}_preview_full_' + str(index).zfill(2)
 
 
 def load_prefs():

--- a/utils.py
+++ b/utils.py
@@ -135,10 +135,16 @@ def get_active_asset():
 
 
 def previmg_name(asset_type: AssetType, index: int, fullsize: bool = False):
+    """Get preview image name for asset_type and index.
+
+    Parameters:
+        asset_type: type of the asset
+        index: index of the asset on the asset bar
+        fullsize: whether it's a big thumbnail
+    """
     if not fullsize:
-        return f'.{HANA3D_NAME}_{asset_type}_preview_' + str(index).zfill(2)
-    else:
-        return f'.{HANA3D_NAME}_{asset_type}_preview_full_' + str(index).zfill(2)
+        return f'.{HANA3D_NAME}_{asset_type}_preview_{str(index).zfill(2)}'
+    return f'.{HANA3D_NAME}_{asset_type}_preview_full_{str(index).zfill(2)}' 
 
 
 def load_prefs():


### PR DESCRIPTION
Separa imagens de preview por asset_type, com nomes do tipo: `.hana3d_dev_model_preview_00`

Resolve um dos problemas da release, mas não totalmente: se vc fizer uma nova search do mesmo asset, por exemplo, elas ainda serão sobrescritas pouco a pouco

EDIT: o único jeito de resolver isso definitivamente seria removendo uma a uma as imagens do `bpy.data.images` quando tem uma nova busca
