### PR TITLE
Fix index 0 out of range

### DIFF
--- a/hana3d/src/ui/operators/asset_bar.py
+++ b/hana3d/src/ui/operators/asset_bar.py
@@ -357,8 +357,11 @@ class AssetBarOperator(bpy.types.Operator):  # noqa: WPS338, WPS214
         for window in context.window_manager.windows:
             areas.extend(window.screen.areas)
 
-        quad_views_differ = self.has_quad_views != bool(self.area.spaces[0].region_quadviews)
-        if self.area not in areas or self.area.type != 'VIEW_3D' or quad_views_differ:
+        if (  # noqa: WPS337
+            self.area not in areas
+            or self.area.type != 'VIEW_3D'
+            or self.has_quad_views != bool(self.area.spaces[0].region_quadviews)
+        ):
             # logging.info('search areas')   bpy.context.area.spaces[0].region_quadviews
             # stopping here model by now - because of:
             #   switching layouts or maximizing area now fails to assign new area throwing the bug


### PR DESCRIPTION
Resolve https://sentry.io/organizations/hana3d/issues/2245039283/?project=5600656&query=is%3Aunresolved

Originalmente, o código estava dessa forma, tinha refatorado isso para passar no linter, mas aparentemente, os checks anteriores precisam ser executados para garantir que o array de `spaces` não seja vazio (acredito que isso seja garantido pelo `3D_VIEW`)