### PR TITLE
Load placeholder if the thumbnail is not found

### DIFF
--- a/hana3d/src/search/search.py
+++ b/hana3d/src/search/search.py
@@ -108,7 +108,8 @@ def load_preview(asset_type: AssetType, search_result: AssetData, index: int):
             img.reload()
         img.colorspace_settings.name = 'Linear'
     else:
-        logging.error('No thumbnail')
+        logging.error(f'No thumbnail in {thumbnail_path}, will load placeholder')
+        load_placeholder_thumbnail(asset_type, index, search_result.id)
 
 
 def load_placeholder_thumbnail(asset_type: AssetType, index: int, asset_id: str):


### PR DESCRIPTION
Não resolve, mas está relacionado com: https://sentry.io/organizations/hana3d/issues/2249427580/?project=5600656&query=is%3Aunresolved

Carrega o placeholder se a thumbnail não estiver salva e loga o nome dela para a gente ter pelo menos mais uma informação do que pode ter acontecido. Gostaria de ter mais informação ainda, mas não acho que tenha muito que possamos colocar aí.