### PR TITLE
Fix results exception

### DIFF
--- a/hana3d/src/search/operator.py
+++ b/hana3d/src/search/operator.py
@@ -179,7 +179,7 @@ class SearchOperator(AsyncModalOperatorMixin, bpy.types.Operator):  # noqa: WPS2
 
     def _parse_response(self, asset_type: AssetType, request_data: Dict) -> List[AssetData]:
         result_field = []
-        for response in request_data['results']:
+        for response in request_data.get('results', []):
             if response['assetType'] != asset_type or not response['files']:
                 continue
 


### PR DESCRIPTION
Acho que resolve [esta exceção](https://sentry.io/organizations/hana3d/issues/2206053777/?project=5600656&query=is%3Aunresolved), mas não tenho tanta certeza porque não conseguir reproduzir o problema explicitamente (e os logs para exceção em tasks são menos explícitos). Em compensação, esse é o único lugar com `'results'` que poderia dar problema e faz sentido conceitualmente.

O problema acontece quando o servidor retorna um 403 (imagino que por causa de uma token expirada) mas a resposta assume que `results` está setado dando provavelmente um `KeyError`