### PR TITLE
Update release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
 
   e2e:
     name: Run E2E tests
+    needs: [lint, tests]
     if: github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set stage
-        run: echo "STAGE=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -18,7 +16,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: make lint
         env:
-          STAGE: ${{ env.STAGE == 'production' && 'production' || 'dev' }}
+          STAGE: dev
   tests:
     name: Run tests
     runs-on: ubuntu-latest
@@ -27,62 +25,23 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.7"
-      - name: Set stage
-        run: echo "STAGE=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - run: scripts/tests/install-blender
         env:
           BLENDER_VERSION: "2.91"
       - run: scripts/tests/install-addon
         env:
           BLENDER_VERSION: "2.91"
-          STAGE: ${{ env.STAGE == 'production' && 'production' || 'dev' }}
+          STAGE: dev
       - run: make install-test
         env:
-          STAGE: ${{ env.STAGE == 'production' && 'production' || 'dev' }}
+          STAGE: dev
       - run: make unit-test
         env:
-          STAGE: ${{ env.STAGE == 'production' && 'production' || 'dev' }}
-  release:
-    name: Release ${{ github.ref == 'refs/heads/production' && 'production' || 'dev' }}
-    needs: [lint, tests]
-    if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/production'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set stage
-        run: echo "STAGE=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Build project
-        run: make build
-        env:
-          STAGE: ${{ env.STAGE }}
-      - name: Set version
-        run: echo "VERSION=$(grep 'version.*[0-9]\+,\s\?[0-9]\+,\s\?[0-9]\+' __init__.py | sed 's/.*\([0-9]\+\),\s\?\([0-9]\+\),\s\?\([0-9]\+\).*/\1.\2.\3/')" >> $GITHUB_ENV
-      - name: Set tag name
-        run: echo "TAG_NAME=${{ env.VERSION }}${{ env.STAGE == 'dev' && '-beta' || '' }}" >> $GITHUB_ENV
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.TAG_NAME }}
-          release_name: ${{ env.TAG_NAME }}
-          body: ${{ github.event.head_commit.message }}
-          draft: ${{ env.STAGE == 'dev' }}
-          prerelease: ${{ env.STAGE == 'dev' }}
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./hana3d_${{ env.STAGE }}.zip
-          asset_name: hana3d_${{ env.STAGE }}.zip
-          asset_content_type: application/zip
+          STAGE: dev
+
   e2e:
     name: Run E2E tests
-    needs: [lint, tests]
-    if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/production'
+    if: github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     steps:
       - uses: convictional/trigger-workflow-and-wait@v1.2.0
@@ -90,5 +49,5 @@ jobs:
           owner: hana3d
           repo: e2e-tests
           github_token: ${{ secrets.HANA3D_BOT_ACCESS_TOKEN }}
-          event_type: ${{ env.STAGE }}
+          event_type: dev
           workflow_file_name: webhook.yml

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,50 @@
+name: Create release
+
+on: workflow_dispatch
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'release')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set version
+        run: echo "VERSION=$(echo $GITHUB_REF | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+$')" >> $GITHUB_ENV
+      - name: Build project
+        run: make build
+        env:
+          STAGE: production
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.VERSION }}
+          release_name: ${{ env.VERSION }}
+          body: ${{ github.event.head_commit.message }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./hana3d_production.zip
+          asset_name: hana3d_production.zip
+          asset_content_type: application/zip
+
+  e2e:
+    name: Run E2E tests
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.2.0
+        with:
+          owner: hana3d
+          repo: e2e-tests
+          github_token: ${{ secrets.HANA3D_BOT_ACCESS_TOKEN }}
+          event_type: production
+          workflow_file_name: webhook.yml

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -9,8 +9,19 @@ jobs:
     if: contains(github.ref, 'release')
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
       - name: Set version
         run: echo "VERSION=$(echo $GITHUB_REF | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+$')" >> $GITHUB_ENV
+      - name: Bump version
+        run: python bump_version.py $VERSION
+      - name: Commit version
+        run: |
+          git config user.name 'Hana3D Bot'
+          git config user.email 'bot@hana3d.com'
+          git commit -m "Bump version"
+          git push
       - name: Build project
         run: make build
         env:
@@ -20,21 +31,21 @@ jobs:
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.VERSION }}
-          release_name: ${{ env.VERSION }}
-          body: ${{ github.event.head_commit.message }}
-          draft: false
-          prerelease: false
+          with:
+            tag_name: ${{ env.VERSION }}
+            release_name: ${{ env.VERSION }}
+            body: ${{ github.event.head_commit.message }}
+            draft: false
+            prerelease: false
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./hana3d_production.zip
-          asset_name: hana3d_production.zip
-          asset_content_type: application/zip
+          with:
+            upload_url: ${{ steps.create_release.outputs.upload_url }}
+            asset_path: ./hana3d_production.zip
+            asset_name: hana3d_production.zip
+            asset_content_type: application/zip
 
   e2e:
     name: Run E2E tests

--- a/bump_version.py
+++ b/bump_version.py
@@ -1,0 +1,18 @@
+import argparse
+import fileinput
+import re
+
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument("version")
+
+args = parser.parse_args()
+major, minor, patch = args.version.split('.')
+
+version_regex = re.compile(r"'version': \(\d+, \d+, \d+\),")
+with fileinput.input(files=('hana3d/__init__.py'), inplace=True) as f:
+    for line in f:
+        if version_regex.search(line):
+            line = re.sub(r"\d+, \d+, \d+", f'{major}, {minor}, {patch}', line)
+        print(line, end='')

--- a/bump_version.py
+++ b/bump_version.py
@@ -1,18 +1,23 @@
+"""Update addon version."""
 import argparse
 import fileinput
 import re
 
-import sys
 
-parser = argparse.ArgumentParser()
-parser.add_argument("version")
+def _main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('version')
 
-args = parser.parse_args()
-major, minor, patch = args.version.split('.')
+    args = parser.parse_args()
+    major, minor, patch = args.version.split('.')
 
-version_regex = re.compile(r"'version': \(\d+, \d+, \d+\),")
-with fileinput.input(files=('hana3d/__init__.py'), inplace=True) as f:
-    for line in f:
-        if version_regex.search(line):
-            line = re.sub(r"\d+, \d+, \d+", f'{major}, {minor}, {patch}', line)
-        print(line, end='')
+    version_regex = re.compile(r"'version': \(\d+, \d+, \d+\),")
+    with fileinput.input(files=('hana3d/__init__.py'), inplace=True) as init_file:
+        for line in init_file:
+            if version_regex.search(line):
+                line = re.sub(r'\d+, \d+, \d+', f'{major}, {minor}, {patch}', line)
+            print(line, end='')  # noqa: WPS421
+
+
+if __name__ == '__main__':
+    _main()


### PR DESCRIPTION
Muda fluxo de gerar uma nova release de mergear na branch `production` para acionar o  workflow via `workflow_dispatch` (como é feito no backend) em uma branch na forma `release-x.x.x` em que `x.x.x` é a versão sendo deployada. Como discutido antes, a ideia é que as releases estejam em branches separadas independentes e não mais na branch `production` permitindo assim deployar um hotfix através de um cherry-pick e não mais precisar mergear tudo que está em dev (mais ou menos da forma em que foi feito a release da 1.1.1).

Esse commit mata a branch `production` (RIP) e para de criar as releases `beta` (acredito eu que elas nunca nem eram usadas). Caso vocês achem que elas são úteis, podemos criá-las na hora do push das branches de release

Estava pensando em fazer um CLI para ajudar a gente a fazer esses hotfixes, vocês acham que vale a pena ou preferem fazer via comandos do git?

To do:

- [x] Atualizar respositório e2e
- [x] Automaticamente comitar versão do addon