### PR TITLE
Fix release not commiting files

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           git config user.name 'Hana3D Bot'
           git config user.email 'bot@hana3d.com'
-          git commit -m "Bump version"
+          git commit -am "Bump version"
           git push
       - name: Build project
         run: make build


### PR DESCRIPTION
Quase funcionou de primeira haha, branch [`release-0.0.1`](https://github.com/hana3d/addon/tree/release-0.0.1) tem um commit mudando a versão feito pelo bot. Vou deixar para ver se a release é gerada corretamente no momento em que fizermos dado que não mudei nada da lógica