### PR TITLE
Fix profile issues

### DIFF
--- a/hana3d/libraries.py
+++ b/hana3d/libraries.py
@@ -25,6 +25,7 @@ from . import paths, rerequests, utils
 from .config import HANA3D_DESCRIPTION, HANA3D_NAME, HANA3D_PROFILE
 from .report_tools import execute_wrapper
 from .src.libraries.libraries import update_libraries_list
+from .src.preferences.profile import Profile
 from .src.search import search
 from .src.unified_props import Unified
 from .src.upload import upload
@@ -41,15 +42,16 @@ def update_libraries(workspace):
     r = rerequests.get(url, headers=headers)
     assert r.ok, f'Failed to get library data: {r.text}'
 
-    profile = bpy.context.window_manager[HANA3D_PROFILE]
-    workspaces = profile['user']['workspaces']
+    profile = Profile().get()
+    if profile:
+        workspaces = profile['user']['workspaces']
 
-    for k, v in enumerate(workspaces):
-        if v['id'] == workspace:
-            workspaces[k]['libraries'] = r.json()
-            break
+        for k, v in enumerate(workspaces):
+            if v['id'] == workspace:
+                workspaces[k]['libraries'] = r.json()
+                break
 
-    profile['user']['workspaces'] = workspaces
+        profile['user']['workspaces'] = workspaces
 
 
 class RemoveLibrarySearch(Operator):

--- a/hana3d/libraries.py
+++ b/hana3d/libraries.py
@@ -46,9 +46,9 @@ def update_libraries(workspace):
     if profile:
         workspaces = profile['user']['workspaces']
 
-        for k, v in enumerate(workspaces):
-            if v['id'] == workspace:
-                workspaces[k]['libraries'] = r.json()
+        for count, element in enumerate(workspaces):
+            if element['id'] == workspace:
+                workspaces[count]['libraries'] = r.json()
                 break
 
         profile['user']['workspaces'] = workspaces

--- a/hana3d/src/preferences/profile.py
+++ b/hana3d/src/preferences/profile.py
@@ -49,6 +49,7 @@ class Profile(object):
 
         if not response.ok:
             logging.error(f'Failed to get profile data: {response.text}')  # noqa: WPS421
+            return
 
         window_manager = bpy.context.window_manager
         window_manager[config.HANA3D_PROFILE] = response.json()


### PR DESCRIPTION
Resolve um problema recorrente com `'hana3d_production_profile' not found` que acontece quando `update_libraries` é chamado antes da profile estar setada (não tenho certeza quando ele acontece).

Percebi também outro problema em que a profile estava sendo setada mesmo quando não deveria dado que a request falhou