### PR TITLE
Fix uncaught exception when closing blender

### DIFF
--- a/hana3d/src/async_loop/__init__.py
+++ b/hana3d/src/async_loop/__init__.py
@@ -146,7 +146,10 @@ class AsyncLoopModalOperator(bpy.types.Operator):
         (re)loads a file. The operator then doesn't get the chance to
         finish the async tasks, hence stop_after_this_kick is never True.
         """
-        self.loop_status.update_operator_status(False)
+        try:
+            self.loop_status.update_operator_status(False)
+        except Exception:
+            logging.info('Could not update loop status, has it been deleted?')
 
     def execute(self, context):
         """Modal execute just calls invoke.


### PR DESCRIPTION
Resolve este problema quando fechando o blender: 
```
Traceback (most recent call last):
  File "/home/ivan/.config/blender/2.91/scripts/addons/hana3d_dev/src/async_loop/__init__.py", line 149, in __del__
    self.loop_status.update_operator_status(False)
  File "/usr/local/src/blender-2.91.2-linux64/2.91/scripts/modules/bpy_types.py", line 721, in __getattribute__
    return super().__getattribute__(attr)
AttributeError: 'AsyncLoopModalOperator' object has no attribute 'loop_status'
```

Acredito que o `unregister_class` delete alguma coisa antes de chamar o `del`. Não muito relevante, mas me incomodava ver uma exceção não ser tratada toda vez que eu precisava reiniciar o blender