### PR TITLE
Fix edit props attribute error

### DIFF
--- a/hana3d/src/panels/upload.py
+++ b/hana3d/src/panels/upload.py
@@ -64,7 +64,7 @@ class Hana3DUploadPanel(Panel):  # noqa: WPS214
         row = layout.row()
         row.scale_y = 2.0
         row.operator(f'message.{HANA3D_NAME}_validation_panel', text='Validate & upload')
-        row.enabled = not hasattr(props, 'asset_index')
+        row.enabled = not hasattr(props, 'asset_index')  # noqa: WPS421
         if props.view_id != '' and unified_props.workspace == props.view_workspace:
             layout.label(text='Asset has a version online.')
 

--- a/hana3d/src/panels/upload.py
+++ b/hana3d/src/panels/upload.py
@@ -64,6 +64,7 @@ class Hana3DUploadPanel(Panel):  # noqa: WPS214
         row = layout.row()
         row.scale_y = 2.0
         row.operator(f'message.{HANA3D_NAME}_validation_panel', text='Validate & upload')
+        row.enabled = not hasattr(props, 'asset_index')
         if props.view_id != '' and unified_props.workspace == props.view_workspace:
             layout.label(text='Asset has a version online.')
 


### PR DESCRIPTION
Resolve essa issue: https://sentry.io/organizations/hana3d/issues/2249773276

Esse problema acontecia ao tentar fazer a validação e upload de material, quando o objeto selecionado não tem nenhum material ativo. Nesse caso o `get_upload_props` retorna um `Hana3DEditAssetProps` no lugar de um `Hana3DUploadProps` (o que está correto, pois nem tem o que fazer upload nesse caso)

Mudei o código para desativar o botão de fazer upload nesse caso, detectando se a prop retornada é de edição ou upload com um `hasattr`

@hana3d/dev 
