### PR TITLE
Random fixes

### DIFF
--- a/hana3d/src/autothumb/__init__.py
+++ b/hana3d/src/autothumb/__init__.py
@@ -257,8 +257,8 @@ class GenerateMaterialThumbnailOperator(bpy.types.Operator):
             self.props = getattr(material, HANA3D_NAME)
             self._generate_material_thumbnail(material)
         except Exception as error:
-            props.is_generating_thumbnail = False
-            props.thumbnail_generating_state = ''
+            self.props.is_generating_thumbnail = False
+            self.props.thumbnail_generating_state = ''
             logging.warning(f'Error while packing file: {str(error)}')
             return {'CANCELLED'}
         return {'FINISHED'}

--- a/hana3d/src/upload/upload.py
+++ b/hana3d/src/upload/upload.py
@@ -28,19 +28,26 @@ def get_upload_props_by_view_id(asset_type: AssetType, view_id: str):
 
     Returns:
         upload props
+
+    Raises:
+        Invalid asset type exception
     """
-    asset = None
-    if asset_type == 'model':
+    if asset_type.lower() == 'model':
         assets = bpy.context.blend_data.objects
-    elif asset_type == 'scene':
+    elif asset_type.lower() == 'scene':
         assets = bpy.data.scenes
-    elif asset_type == 'material':
+    elif asset_type.lower() == 'material':
         assets = bpy.data.materials
+    else:
+        raise Exception(f'Invalid asset type: {asset_type}')
 
     assets = [
         ob
         for ob in assets
         if getattr(ob, HANA3D_NAME) and getattr(ob, HANA3D_NAME).view_id == view_id
     ]
-    asset = assets[0]
-    return getattr(asset, HANA3D_NAME)
+
+    if not assets:
+        return None
+
+    return getattr(assets[0], HANA3D_NAME)


### PR DESCRIPTION
Resolve (acho) dois problemas do sentry:

1. [NameError: name 'props' is not defined](https://sentry.io/organizations/hana3d/issues/2259864415/) - props -> self.props
2. [UnboundLocalError: local variable 'assets' referenced before assignment](https://sentry.io/organizations/hana3d/issues/2252781880) - pelos logs, mais um caso de 'MODEL' vs 'model' nos assombrando. Mudei a `get_upload_props_by_view_id` pra levantar uma exceção com AssetType errado e/ou retornar None dependendo do caso

@hana3d/dev 