### PR TITLE
fixes for render

### DIFF
--- a/hana3d/autothumb.py
+++ b/hana3d/autothumb.py
@@ -70,7 +70,7 @@ def generate_model_thumbnail(
         i += 1
 
     filepath = os.path.join(tempdir, "thumbnailer_" + HANA3D_NAME + ext)
-    tfpath = paths.get_thumbnailer_filepath()
+    tfpath = paths.get_thumbnailer_filepath('model')
     datafile = os.path.join(tempdir, HANA3D_EXPORT_DATA_FILE)
 
     autopack = False
@@ -231,7 +231,7 @@ def generate_material_thumbnail(
         i += 1
 
     filepath = os.path.join(tempdir, "material_thumbnailer_cycles" + ext)
-    tfpath = paths.get_material_thumbnailer_filepath()
+    tfpath = paths.get_thumbnailer_filepath('material')
     datafile = os.path.join(tempdir, HANA3D_EXPORT_DATA_FILE)
 
     utils.save_file(filepath, compress=False, copy=True)

--- a/hana3d/render.py
+++ b/hana3d/render.py
@@ -247,7 +247,7 @@ class RenderThread(UploadFileMixin, threading.Thread):
             self._set_running_flag(False)
             time.sleep(5)
             self.update_state(self.log_state_name, '')
-            # Can't run asyncio inside thread
+            # TODO: use asyncio (can't run asyncio inside thread)
             # profile = Profile()   # noqa: E800
             # run_async_function(profile.update_async)  # noqa: E800
 

--- a/hana3d/render.py
+++ b/hana3d/render.py
@@ -37,8 +37,8 @@ from bpy_extras.image_utils import load_image
 from . import autothumb, paths, render_tools, rerequests, thread_tools
 from .config import HANA3D_DESCRIPTION, HANA3D_NAME, HANA3D_RENDER
 from .report_tools import execute_wrapper
-# from .src.async_loop import run_async_function
-# from .src.preferences.profile import Profile
+# from .src.async_loop import run_async_function    # noqa: E800
+# from .src.preferences.profile import Profile  # noqa: E800
 from .src.ui import colors
 from .src.ui.main import UI
 from .src.upload import upload
@@ -248,8 +248,8 @@ class RenderThread(UploadFileMixin, threading.Thread):
             time.sleep(5)
             self.update_state(self.log_state_name, '')
             # Can't run asyncio inside thread
-            # profile = Profile()
-            # run_async_function(profile.update_async)
+            # profile = Profile()   # noqa: E800
+            # run_async_function(profile.update_async)  # noqa: E800
 
     def _set_running_flag(self, flag: bool):
         if self.is_thumbnail:

--- a/hana3d/render.py
+++ b/hana3d/render.py
@@ -37,8 +37,8 @@ from bpy_extras.image_utils import load_image
 from . import autothumb, paths, render_tools, rerequests, thread_tools
 from .config import HANA3D_DESCRIPTION, HANA3D_NAME, HANA3D_RENDER
 from .report_tools import execute_wrapper
-from .src.async_loop import run_async_function
-from .src.preferences.profile import Profile
+# from .src.async_loop import run_async_function
+# from .src.preferences.profile import Profile
 from .src.ui import colors
 from .src.ui.main import UI
 from .src.upload import upload
@@ -247,8 +247,9 @@ class RenderThread(UploadFileMixin, threading.Thread):
             self._set_running_flag(False)
             time.sleep(5)
             self.update_state(self.log_state_name, '')
-            profile = Profile()
-            run_async_function(profile.update_async)
+            # Can't run asyncio inside thread
+            # profile = Profile()
+            # run_async_function(profile.update_async)
 
     def _set_running_flag(self, flag: bool):
         if self.is_thumbnail:

--- a/hana3d/src/autothumb/__init__.py
+++ b/hana3d/src/autothumb/__init__.py
@@ -126,8 +126,8 @@ class GenerateModelThumbnailOperator(bpy.types.Operator):
             self.props = getattr(main_model, HANA3D_NAME)
             self._generate_model_thumbnail(main_model)
         except Exception as error:
-            props.is_generating_thumbnail = False
-            props.thumbnail_generating_state = ''
+            self.props.is_generating_thumbnail = False
+            self.props.thumbnail_generating_state = ''
             UI().add_report(f'Error in thumbnailer: {error}', color=colors.RED)
             return {'CANCELLED'}
         return {'FINISHED'}


### PR DESCRIPTION
@hana3d/dev 

O ideal seria refatorar o `render` para usar asyncio no lugar de threading, mas isso deve resolver por enquanto.