### PR TITLE
Show tooltip with placeholder thumbnail

### DIFF
--- a/hana3d/src/edit_asset/operators.py
+++ b/hana3d/src/edit_asset/operators.py
@@ -1,4 +1,5 @@
 """Edit assets operators."""
+import logging
 import uuid
 
 import bpy
@@ -40,7 +41,10 @@ class EditAssetOperator(AsyncModalOperatorMixin, bpy.types.Operator):  # noqa: W
         props = get_edit_props()
         asset_data, view_data = get_edit_data(props)
 
+        logging.debug(f'Editing asset: new data is {asset_data}')
         await edit_asset(ui, correlation_id, props.id, asset_data)
+
+        logging.debug(f'Editing view: new data is {view_data}')
         await edit_view(ui, correlation_id, props.view_id, view_data)
 
         search.run_operator()

--- a/hana3d/src/search/search.py
+++ b/hana3d/src/search/search.py
@@ -88,7 +88,9 @@ def load_preview(asset_type: AssetType, search_result: AssetData, index: int):
 
     if search_result.thumbnail_small == '':
         logging.debug('No small thumbnail, will load placeholder')
-        load_placeholder_thumbnail(asset_type, index, search_result.id)
+        placeholder_path = load_placeholder_thumbnail(asset_type, index, search_result.id)
+        search_result.thumbnail_small = placeholder_path
+        search_result.thumbnail = placeholder_path
         return
 
     thumbnail_path = os.path.join(directory, search_result.thumbnail_small)
@@ -120,6 +122,9 @@ def load_placeholder_thumbnail(asset_type: AssetType, index: int, asset_id: str)
         asset_type: asset type
         index: index number of the asset in search results
         asset_id: asset id
+    
+    Returns:
+        placeholder_path: path to the placeholder thumbnail
     """
     placeholder_path = paths.get_addon_thumbnail_path('thumbnail_notready.png')
 
@@ -131,6 +136,7 @@ def load_placeholder_thumbnail(asset_type: AssetType, index: int, asset_id: str)
 
     fullsize_img = bpy.data.images.load(placeholder_path)
     fullsize_img.name = utils.previmg_name(asset_type, index, fullsize=True)
+    return placeholder_path
 
 
 def get_search_results(asset_type: AssetType = None) -> List[AssetData]:

--- a/hana3d/src/search/search.py
+++ b/hana3d/src/search/search.py
@@ -115,14 +115,14 @@ def load_preview(asset_type: AssetType, search_result: AssetData, index: int):
         load_placeholder_thumbnail(asset_type, index, search_result.id)
 
 
-def load_placeholder_thumbnail(asset_type: AssetType, index: int, asset_id: str):
+def load_placeholder_thumbnail(asset_type: AssetType, index: int, asset_id: str) -> str:
     """Load placeholder thumbnail for assets without one.
 
     Parameters:
         asset_type: asset type
         index: index number of the asset in search results
         asset_id: asset id
-    
+
     Returns:
         placeholder_path: path to the placeholder thumbnail
     """

--- a/hana3d/src/search/search.py
+++ b/hana3d/src/search/search.py
@@ -124,7 +124,7 @@ def load_placeholder_thumbnail(asset_type: AssetType, index: int, asset_id: str)
         asset_id: asset id
 
     Returns:
-        placeholder_path: path to the placeholder thumbnail
+        str: placeholder_path
     """
     placeholder_path = paths.get_addon_thumbnail_path('thumbnail_notready.png')
 


### PR DESCRIPTION
Antes esses atributos ficavam como "", então a thumbnail era buscada em: `{HANA3D_DATA}/temp/model_search/`, que é uma path válida, mas que não tem a imagem

Coloquei também uns logs no `edit_asset` para debugar o problema das libraries

@hana3d/dev 