### PR TITLE
Replace scene_update hook for depsgraph_update

### DIFF
--- a/hana3d/addon_updater_ops.py
+++ b/hana3d/addon_updater_ops.py
@@ -702,7 +702,7 @@ def post_update_callback(module_name, res=None):
         # this is the same code as in conditional at the end of the register function
         # ie if "auto_reload_post_update" is True, comment out this code
         logging.debug('{0} updater: Running post update callback'.format(updater.addon))
-        # bpy.app.handlers.depsgraph_update_post.append(updater_run_success_popup_handler)
+        # bpy.app.handlers.depsgraph_update_post.append(updater_run_success_popup_handler) # noqa: E800, E501
 
         atr = addon_updater_updated_successful.bl_idname.split(".")
         getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')

--- a/hana3d/addon_updater_ops.py
+++ b/hana3d/addon_updater_ops.py
@@ -622,7 +622,7 @@ def updater_run_success_popup_handler(scene):
         return
 
     try:
-        bpy.app.handlers.scene_update_post.remove(updater_run_success_popup_handler)
+        bpy.app.handlers.depsgraph_update_post.remove(updater_run_success_popup_handler)
     except Exception:
         pass
 
@@ -640,7 +640,7 @@ def updater_run_install_popup_handler(scene):
         return
 
     try:
-        bpy.app.handlers.scene_update_post.remove(updater_run_install_popup_handler)
+        bpy.app.handlers.depsgraph_update_post.remove(updater_run_install_popup_handler)
     except Exception:
         pass
 
@@ -676,10 +676,10 @@ def background_update_callback(update_ready):
     if update_ready is not True:
         return
     if (
-        updater_run_install_popup_handler not in bpy.app.handlers.scene_update_post
+        updater_run_install_popup_handler not in bpy.app.handlers.depsgraph_update_post
         and ran_autocheck_install_popup is False
     ):
-        bpy.app.handlers.scene_update_post.append(updater_run_install_popup_handler)
+        bpy.app.handlers.depsgraph_update_post.append(updater_run_install_popup_handler)
         ran_autocheck_install_popup = True
 
 
@@ -702,7 +702,7 @@ def post_update_callback(module_name, res=None):
         # this is the same code as in conditional at the end of the register function
         # ie if "auto_reload_post_update" is True, comment out this code
         logging.debug('{0} updater: Running post update callback'.format(updater.addon))
-        # bpy.app.handlers.scene_update_post.append(updater_run_success_popup_handler)
+        # bpy.app.handlers.depsgraph_update_post.append(updater_run_success_popup_handler)
 
         atr = addon_updater_updated_successful.bl_idname.split(".")
         getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
@@ -811,10 +811,10 @@ def showReloadPopup():
             return
 
         if (
-            updater_run_success_popup_handler not in bpy.app.handlers.scene_update_post
+            updater_run_success_popup_handler not in bpy.app.handlers.depsgraph_update_post
             and ran_update_sucess_popup is False
         ):
-            bpy.app.handlers.scene_update_post.append(updater_run_success_popup_handler)
+            bpy.app.handlers.depsgraph_update_post.append(updater_run_success_popup_handler)
             ran_update_sucess_popup = True
 
 


### PR DESCRIPTION
Issue no sentry: https://sentry.io/organizations/hana3d/issues/2321809719/?project=5600656&query=is%3Aunresolved

Ok, esse problema é estranho. Aparentemente a última versão com `scene_update_post` é a [2.79](https://docs.blender.org/api/2.79/bpy.app.handlers.html#bpy.app.handlers.scene_update_post) e a descrição desse hook é: 
> on every scene data update. Does not imply that anything changed in the scene, just that the dependency graph was reevaluated, and the scene was possibly updated by Blender’s animation system.

Na [2.80](https://docs.blender.org/api/2.80/bpy.app.handlers.html), esse hook não existe mais, sendo substituído pelo `depsgraph_update_post` (? não encontrei nenhuma menção a isso nas release notes, mas imagino que seja o caso pela descrição e pela mudança um menor uso da cena a partir da 2.80). A questão que fica é: isso importa? Até hoje não aparentou dar problema, mas chega a ser estranho que não tenha dado

@hana3d/dev 