### PR TITLE
Skip when image has both sides equal to zero

### DIFF
--- a/hana3d/src/ui/callbacks/asset_bar.py
+++ b/hana3d/src/ui/callbacks/asset_bar.py
@@ -403,6 +403,7 @@ def draw_callback2d_search(self, context):
 
                 max_size = max(img.size[0], img.size[1])
                 if max_size == 0:
+                    logging.error(f'Image with name {iname} has both sides equal to zero, skipping')
                     continue
 
                 width = int(ui_props.thumb_size * img.size[0] / max_size)

--- a/hana3d/src/ui/callbacks/asset_bar.py
+++ b/hana3d/src/ui/callbacks/asset_bar.py
@@ -402,6 +402,9 @@ def draw_callback2d_search(self, context):
                     continue
 
                 max_size = max(img.size[0], img.size[1])
+                if max_size == 0:
+                    continue
+
                 width = int(ui_props.thumb_size * img.size[0] / max_size)
                 height = int(ui_props.thumb_size * img.size[1] / max_size)
                 crop = (0, 0, 1, 1)


### PR DESCRIPTION
https://sentry.io/organizations/hana3d/issues/2264786387/?project=5600656&query=is%3Aunresolved

Não sei o que causa isso, mas parece um check válido

@hana3d/dev 