### PR TITLE
Reduce non-square textures validation to warning

### DIFF
--- a/hana3d/src/validators/square_textures.py
+++ b/hana3d/src/validators/square_textures.py
@@ -67,4 +67,4 @@ def check_texture_dimension(asset_type: AssetType, export_data: dict) -> Tuple[b
 
 name = 'Square Textures'
 description = 'Checks if texture is square'
-square_textures = BaseValidator(name, Category.error, description, check_texture_dimension)
+square_textures = BaseValidator(name, Category.warning, description, check_texture_dimension)

--- a/hana3d/src/validators/textures_size.py
+++ b/hana3d/src/validators/textures_size.py
@@ -96,7 +96,7 @@ name = 'Textures Size'
 description = 'Checks if texture size is potency of 2 and <= 2048'
 textures_size = BaseValidator(
     name,
-    Category.error,
+    Category.warning,
     description,
     check_textures_size,
     fix_textures_size,


### PR DESCRIPTION
Algumas texturas precisam ser retângulos (textos/imagens)

@hana3d/dev 