### PR TITLE
Load placeholder on invalid thumbnails

### DIFF
--- a/hana3d/src/search/search.py
+++ b/hana3d/src/search/search.py
@@ -90,7 +90,7 @@ def load_preview(asset_type: AssetType, search_result: AssetData, index: int):
         logging.debug('No small thumbnail, will load placeholder')
         placeholder_path = load_placeholder_thumbnail(asset_type, index, search_result.id)
         search_result.thumbnail_small = placeholder_path
-        search_result.thumbnail = placeholder_path
+        search_result.thumbnail = ''
         return
 
     thumbnail_path = os.path.join(directory, search_result.thumbnail_small)
@@ -110,9 +110,12 @@ def load_preview(asset_type: AssetType, search_result: AssetData, index: int):
             img.reload()
         img.colorspace_settings.name = 'Linear'
 
-    if bpy.data.images.get(image_name) is None:
+    img = bpy.data.images.get(image_name)
+    if img is None or img.size[0] == 0 or img.size[1] == 0:
         logging.error(f'No thumbnail in {thumbnail_path}, will load placeholder')
-        load_placeholder_thumbnail(asset_type, index, search_result.id)
+        placeholder_path = load_placeholder_thumbnail(asset_type, index, search_result.id)
+        search_result.thumbnail_small = placeholder_path
+        search_result.thumbnail = ''
 
 
 def load_placeholder_thumbnail(asset_type: AssetType, index: int, asset_id: str) -> str:

--- a/hana3d/src/ui/callbacks/asset_bar.py
+++ b/hana3d/src/ui/callbacks/asset_bar.py
@@ -415,10 +415,6 @@ def draw_callback2d_search(self, context):
                     continue
 
                 max_size = max(img.size[0], img.size[1])
-                if max_size == 0:
-                    logging.error(f'Image with name {iname} has both sides equal to zero, skipping')
-                    continue
-
                 width = int(ui_props.thumb_size * img.size[0] / max_size)
                 height = int(ui_props.thumb_size * img.size[1] / max_size)
                 crop = (0, 0, 1, 1)


### PR DESCRIPTION
Resolve dois problemas: 
- Algumas thumbnails colocadas via ingestão estavam quebradas (tamanho zero) o que estragava todo o search: coloquei para carregar o placeholder nesse caso
- Quando carregava o placeholder, "falhava" para colocar o modelo na cena com o erro: `No such file or directory: '/home/ivan/hana3d_production_data/temp/model_search/thumbnail_notready.png'` porque ele tentava achar a thumbnail sem ser o placeholder. Mudei para não carregar nenhuma thumbnail nesse caso
@hana3d/dev 