### PR TITLE
fix asyncio modal when already running

### DIFF
--- a/hana3d/__init__.py
+++ b/hana3d/__init__.py
@@ -51,7 +51,7 @@ from .src.ui.operators import render_image
 bl_info = {
     'name': 'Hana3D',
     'author': 'Vilem Duha, Petr Dlouhy, R2U',
-    'version': (1, 1, 1),
+    'version': (1, 3, 2),
     'blender': (2, 91, 0),
     'location': 'View3D > Properties > Hana3D',
     'description': 'Online Hana3D library (materials, models, scenes and more). Connects to the internet.',  # noqa: E501

--- a/hana3d/src/async_loop/__init__.py
+++ b/hana3d/src/async_loop/__init__.py
@@ -174,7 +174,7 @@ class AsyncLoopModalOperator(bpy.types.Operator):
         """
         if self.loop_status.get_operator_status():
             self.log.debug('Another loop-kicking operator is already running.')
-            return {'PASS_THROUGH'}
+            return {'RUNNING_MODAL'}
 
         context.window_manager.modal_handler_add(self)
         self.loop_status.update_operator_status(True)


### PR DESCRIPTION
Isso parece resolver o problema de ficar travado quando chamava duas operações async, o que estava acontecendo é que o modal do async não se mantia rodando quando entrava nessa condição
@hana3d/dev 