### PR TITLE
fixes for 2.93

### DIFF
--- a/hana3d/__init__.py
+++ b/hana3d/__init__.py
@@ -120,7 +120,6 @@ def check_timers_timer():
     return 5.0
 
 
-@ addon_updater_ops.make_annotations
 class Hana3DAddonPreferences(AddonPreferences):
     # this must match the addon name, use '__package__'
     # when defining this in a submodule of a python package.
@@ -261,32 +260,32 @@ class Hana3DAddonPreferences(AddonPreferences):
         update=utils.save_prefs,
     )
 
-    auto_check_update = bpy.props.BoolProperty(
+    auto_check_update: bpy.props.BoolProperty(
         name="Auto-check for Update",
         description="If enabled, auto-check for updates using an interval",
         default=False,
     )
-    updater_intrval_months = bpy.props.IntProperty(
+    updater_intrval_months: bpy.props.IntProperty(
         name='Months',
         description="Number of months between checking for updates",
         default=0,
         min=0
     )
-    updater_intrval_days = bpy.props.IntProperty(
+    updater_intrval_days: bpy.props.IntProperty(
         name='Days',
         description="Number of days between checking for updates",
         default=7,
         min=0,
         max=31,
     )
-    updater_intrval_hours = bpy.props.IntProperty(
+    updater_intrval_hours: bpy.props.IntProperty(
         name='Hours',
         description="Number of hours between checking for updates",
         default=0,
         min=0,
         max=23,
     )
-    updater_intrval_minutes = bpy.props.IntProperty(
+    updater_intrval_minutes: bpy.props.IntProperty(
         name='Minutes',
         description="Number of minutes between checking for updates",
         default=0,

--- a/hana3d/addon_updater_ops.py
+++ b/hana3d/addon_updater_ops.py
@@ -68,21 +68,6 @@ updater.addon = HANA3D_NAME
 # -----------------------------------------------------------------------------
 
 
-def make_annotations(cls):
-    """Add annotation attribute to class fields to avoid Blender 2.8 warnings"""
-    if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
-        return cls
-    bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
-    if bl_props:
-        if '__annotations__' not in cls.__dict__:
-            setattr(cls, '__annotations__', {})
-        annotations = cls.__dict__['__annotations__']
-        for k, v in bl_props.items():
-            annotations[k] = v
-            delattr(cls, k)
-    return cls
-
-
 def layout_split(layout, factor=0.0, align=False):
     """Intermediate method for pre and post blender 2.8 split UI function"""
     if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):

--- a/hana3d/addon_updater_ops.py
+++ b/hana3d/addon_updater_ops.py
@@ -295,7 +295,7 @@ class addon_updater_install_manually(bpy.types.Operator):
     bl_description = "Proceed to manually install update"
     bl_options = {'REGISTER', 'INTERNAL'}
 
-    error: bpy.props.StringProperty(name="Error Occurred", default="", options={'HIDDEN'})
+    error: bpy.props.StringProperty(name='Error Occurred', default='', options={'HIDDEN'})
 
     def invoke(self, context, event):
         return context.window_manager.invoke_popup(self)
@@ -353,7 +353,7 @@ class addon_updater_updated_successful(bpy.types.Operator):
     bl_description = "Update installation response"
     bl_options = {'REGISTER', 'INTERNAL', 'UNDO'}
 
-    error: bpy.props.StringProperty(name="Error Occurred", default="", options={'HIDDEN'})
+    error: bpy.props.StringProperty(name='Error Occurred', default='', options={'HIDDEN'})
 
     def invoke(self, context, event):
         return context.window_manager.invoke_props_popup(self, event)
@@ -1208,7 +1208,6 @@ def register(bl_info):
     # in the addon, delete these lines (also from unregister)
     for cls in classes:
         # apply annotations to remove Blender 2.8 warnings, no effect on 2.7
-        # make_annotations(cls)
         # comment out this line if using bpy.utils.register_module(__name__)
         bpy.utils.register_class(cls)
 

--- a/hana3d/addon_updater_ops.py
+++ b/hana3d/addon_updater_ops.py
@@ -158,7 +158,7 @@ class addon_updater_update_now(bpy.types.Operator):
     # if true, run clean install - ie remove all files before adding new
     # equivalent to deleting the addon and reinstalling, except the
     # updater folder/backup folder remains
-    clean_install = bpy.props.BoolProperty(
+    clean_install: bpy.props.BoolProperty(
         name="Clean install",
         description="If enabled, completely clear the addon's folder"
         " before installing new update, creating a fresh install",
@@ -226,7 +226,7 @@ class addon_updater_update_target(bpy.types.Operator):
             i += 1
         return ret
 
-    target = bpy.props.EnumProperty(
+    target: bpy.props.EnumProperty(
         name="Target version to install",
         description="Select the version to install",
         items=target_version,
@@ -235,7 +235,7 @@ class addon_updater_update_target(bpy.types.Operator):
     # if true, run clean install - ie remove all files before adding new
     # equivalent to deleting the addon and reinstalling, except the
     # updater folder/backup folder remains
-    clean_install = bpy.props.BoolProperty(
+    clean_install: bpy.props.BoolProperty(
         name="Clean install",
         description="If enabled, completely clear the addon's folder"
         " before installing new update, creating a fresh install",
@@ -295,7 +295,7 @@ class addon_updater_install_manually(bpy.types.Operator):
     bl_description = "Proceed to manually install update"
     bl_options = {'REGISTER', 'INTERNAL'}
 
-    error = bpy.props.StringProperty(name="Error Occurred", default="", options={'HIDDEN'})
+    error: bpy.props.StringProperty(name="Error Occurred", default="", options={'HIDDEN'})
 
     def invoke(self, context, event):
         return context.window_manager.invoke_popup(self)
@@ -353,7 +353,7 @@ class addon_updater_updated_successful(bpy.types.Operator):
     bl_description = "Update installation response"
     bl_options = {'REGISTER', 'INTERNAL', 'UNDO'}
 
-    error = bpy.props.StringProperty(name="Error Occurred", default="", options={'HIDDEN'})
+    error: bpy.props.StringProperty(name="Error Occurred", default="", options={'HIDDEN'})
 
     def invoke(self, context, event):
         return context.window_manager.invoke_props_popup(self, event)
@@ -1208,7 +1208,7 @@ def register(bl_info):
     # in the addon, delete these lines (also from unregister)
     for cls in classes:
         # apply annotations to remove Blender 2.8 warnings, no effect on 2.7
-        make_annotations(cls)
+        # make_annotations(cls)
         # comment out this line if using bpy.utils.register_module(__name__)
         bpy.utils.register_class(cls)
 

--- a/hana3d/config/__init__.py
+++ b/hana3d/config/__init__.py
@@ -4,7 +4,7 @@ from .. import wheels
 
 wheels.load_wheels()
 
-config_dirname = os.path.dirname(os.path.realpath(__file__))
+config_dirname = os.path.dirname(os.path.abspath(__file__))
 addon_dirname = os.path.dirname(config_dirname)
 hana3d_stage = os.path.basename(addon_dirname)
 _, stage = hana3d_stage.split('_')

--- a/hana3d/src/async_loop/__init__.py
+++ b/hana3d/src/async_loop/__init__.py
@@ -51,7 +51,12 @@ def kick_async_loop() -> bool:  # noqa : WPS210,WPS213,WPS231
         log.warning('loop closed, stopping immediately.')
         return True
 
-    all_tasks = asyncio.Task.all_tasks()
+    try:
+        all_tasks = asyncio.all_tasks(loop=loop)
+    except AttributeError as e:
+        log.debug(e)
+        all_tasks = asyncio.Task.all_tasks()
+
     if not len(all_tasks):
         log.debug('no more scheduled tasks, stopping after this kick.')
         stop_after_this_kick = True

--- a/hana3d/src/async_loop/__init__.py
+++ b/hana3d/src/async_loop/__init__.py
@@ -53,8 +53,8 @@ def kick_async_loop() -> bool:  # noqa : WPS210,WPS213,WPS231
 
     try:
         all_tasks = asyncio.all_tasks(loop=loop)
-    except AttributeError as e:
-        log.debug(e)
+    except AttributeError as error:
+        log.debug(error)
         all_tasks = asyncio.Task.all_tasks()
 
     if not len(all_tasks):

--- a/hana3d/src/panels/panel_builder.py
+++ b/hana3d/src/panels/panel_builder.py
@@ -10,7 +10,7 @@ from .search import Hana3DSearchPanel
 from .updater import Hana3DUpdaterPanel
 from .upload import Hana3DUploadPanel
 from ..search import search
-from ... import addon_updater_ops, utils
+from ... import utils
 from ...config import HANA3D_NAME, HANA3D_UI
 
 

--- a/hana3d/src/panels/panel_builder.py
+++ b/hana3d/src/panels/panel_builder.py
@@ -45,7 +45,6 @@ panels = (
 
 def register():
     """Register panel in Blender."""
-    addon_updater_ops.make_annotations(Hana3DUpdaterPanel)
     for panel in panels:
         bpy.utils.register_class(panel)
     bpy.types.VIEW3D_MT_editor_menus.append(header_search_draw)
@@ -53,7 +52,6 @@ def register():
 
 def unregister():
     """Unregister panel in Blender."""
-    addon_updater_ops.make_annotations(Hana3DUpdaterPanel)
     for panel in reversed(panels):
         bpy.utils.unregister_class(panel)
     bpy.types.VIEW3D_MT_editor_menus.remove(header_search_draw)


### PR DESCRIPTION
Eu estava testando na versão 2.93 do Blender e apareceu alguns problemas. Uma mudança importante é que não aceita mais propriedades que não estejam como annotations, não é tão ruim porque já estavamos fazendo assim, mas o updater fazia da forma antiga e tentava ajustar com uma gambiarra para annotation, mas parece que ela não estava funcionando direito.
As mudanças mais significativas na verdade estão relacionadas com o Python do Blender agora ser o 3.9.
Eu mudei de forma a funcionar nas versões anteriores também.

@hana3d/dev 