### PR TITLE
Fix edit and download for blender 2.93

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endef
 
 export PYTHON=python
 export PRINT_HELP_PYSCRIPT
-export BLENDER_VERSION=2.91
+export BLENDER_VERSION=2.93
 SHELL=/bin/bash -o pipefail
 BLENDER_SCRIPTS_PATH ?= $(shell dirname $(shell readlink -f $(shell which blender)))/$(BLENDER_VERSION)/scripts/
 STAGE ?= production

--- a/hana3d/hana3d_types.py
+++ b/hana3d/hana3d_types.py
@@ -491,15 +491,6 @@ class Hana3DCommonUploadProps:
             thumbnail_preview.load(name, bpy.path.abspath(self.thumbnail), 'IMAGE')
             self.thumbnail_icon_id = thumbnail_preview[name].icon_id
 
-    def clear_data(self):
-        """Set all properties to their default values"""
-        for cls in self.__class__.mro():
-            if not hasattr(cls, '__annotations__'):
-                continue
-            for attr, (type_, kwargs) in cls.__annotations__.items():
-                if 'default' in kwargs:
-                    setattr(self, attr, kwargs['default'])
-
     id: StringProperty(
         name="Asset Id",
         description="ID of the asset (hidden)",

--- a/hana3d/src/download/__init__.py
+++ b/hana3d/src/download/__init__.py
@@ -427,7 +427,6 @@ def import_material(asset_data: AssetData, file_names: list, **kwargs):
 
 def set_asset_props(asset, asset_data):
     asset_props = getattr(asset, HANA3D_NAME)
-    asset_props.clear_data()
     asset['asset_data'] = asdict(asset_data)
 
     set_thumbnail(asset_data, asset)

--- a/hana3d/src/edit_asset/edit.py
+++ b/hana3d/src/edit_asset/edit.py
@@ -34,7 +34,6 @@ def set_edit_props(asset_index: int):
     asset_props = get_edit_props()
     search_results = get_search_results()
     asset_data = search_results[asset_index]
-    asset_props.clear_data()
 
     asset_props.id = asset_data.id  # noqa: WPS125
     asset_props.view_id = asset_data.view_id


### PR DESCRIPTION
Essa função não estava funcionando corretamente no Blender 2.93. O problema é que a forma como as annotations eram acessadas foi alterada. Agora para essa função funcionar precisaria mudar o segundo loop para algo na forma:

```python
for attr, value in cls.__annotations__.items():
    if 'default' in value.keywords:
```

Entretanto, isso não me parecia compatível com versões anteriores e essa função não parecia necessária vendo onde ela era usada. Além disso, [acessar as annotations assim não é recomendado](https://developer.blender.org/T87465)

@hana3d/dev 